### PR TITLE
xNWP: replace deadlinks with github link.

### DIFF
--- a/xNWP.md
+++ b/xNWP.md
@@ -2,7 +2,7 @@
 name: Brett 'xNWP' Anthony
 member: true
 date_from: 2017-06-01
-links: https://thatnwp.com, https://www.paypal.me/xNWP
+links: https://github.com/xNWP
 contributions: code, maintenance, review, question, plugin, tutorial
 ---
 Programming of additional tools, Discord moderator. Past: Reddit Moderator.


### PR DESCRIPTION
thatnwp.com domain is no longer owned by me.